### PR TITLE
Enforce a minimum max height

### DIFF
--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -315,7 +315,7 @@ export default function TraceablePeerConnection(
      * The height constraint applied on the video sender. The default value is 2160 (4K) when layer suspension is
      * explicitly disabled.
      */
-    this._senderVideoMaxHeight = 2160;
+    this._senderVideoMaxHeight = 720;
 
     /**
      * The height constraints to be applied on the sender per local video source (source name as the key).
@@ -2587,6 +2587,10 @@ TraceablePeerConnection.prototype.setRemoteDescription = function(description) {
 TraceablePeerConnection.prototype.setSenderVideoConstraints = function(frameHeight, localVideoTrack) {
     if (frameHeight < 0) {
         throw new Error(`Invalid frameHeight: ${frameHeight}`);
+    }
+
+    if (frameHeight === undefined) {
+        frameHeight = this._senderVideoMaxHeight;
     }
 
     const sourceName = localVideoTrack.getSourceName();

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1577,6 +1577,7 @@ export default class JingleSessionPC extends JingleSession {
      */
     setSenderVideoConstraint(maxFrameHeight, sourceName = null) {
         let maxToUse = maxFrameHeight;
+
         if (!maxFrameHeight || maxFrameHeight < 0) {
             maxToUse = 480;
         }

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1576,14 +1576,19 @@ export default class JingleSessionPC extends JingleSession {
      * successful and rejected otherwise.
      */
     setSenderVideoConstraint(maxFrameHeight, sourceName = null) {
+        let maxToUse = maxFrameHeight;
+        if (!maxFrameHeight || maxFrameHeight < 0) {
+            maxToUse = 480;
+        }
+
         if (this._assertNotEnded()) {
-            logger.info(`${this} setSenderVideoConstraint: ${maxFrameHeight}, sourceName: ${sourceName}`);
+            logger.info(`${this} setSenderVideoConstraint: ${maxToUse}, sourceName: ${sourceName}`);
 
             const jitsiLocalTrack = sourceName
                 ? this.rtc.getLocalVideoTracks().find(track => track.getSourceName() === sourceName)
                 : this.rtc.getLocalVideoTrack();
 
-            return this.peerconnection.setSenderVideoConstraints(maxFrameHeight, jitsiLocalTrack);
+            return this.peerconnection.setSenderVideoConstraints(maxToUse, jitsiLocalTrack);
         }
 
         return Promise.resolve();


### PR DESCRIPTION
In some cases, frame height may be passed as undefined, we want to avoid this

This does avoid the encoding being disabled, I believe it can have an impact on bandwidth, though I'm not sure in which cases this can get passed through as undefined, but it seems to result in our black webcam issue